### PR TITLE
Mobile Menu styling adjustment

### DIFF
--- a/css/asu-header-footer.css
+++ b/css/asu-header-footer.css
@@ -308,21 +308,8 @@
     outline: 0;
 }
 
-#header-main .navbar-toggler .fa-stack {
-    width: 0.875em;
-    height: 1em;
-}
-
 #header-main .navbar-toggler .fa-circle {
     color: #e8e8e8;
-    font-size: 1rem;
-    margin-left: -12px;
-    /* Magic number, align icon with hamburger */
-}
-
-#header-main .navbar-toggler .fa-times {
-    margin-left: -5px;
-    /* Magic number, same thing */
 }
 
 #header-main .navbar-toggler.collapsed .fa-stack {


### PR DESCRIPTION
fix for alignment of the stacked icon in the mobile menu for the X close button
please test to make sure its not just a fix that applies to my environment
before:
<img width="131" alt="Screen Shot 2021-02-03 at 10 58 59 AM" src="https://user-images.githubusercontent.com/5439169/106788924-d4298c00-660e-11eb-8f26-cd0e300522e6.png">
after:
<img width="129" alt="Screen Shot 2021-02-03 at 10 59 25 AM" src="https://user-images.githubusercontent.com/5439169/106788972-e3103e80-660e-11eb-8c79-6a38e5f5b424.png">

would fix https://github.com/asulibraries/islandora-repo/issues/296